### PR TITLE
Feature/dependency review

### DIFF
--- a/src/Rhythm.Caching.Umbraco/Properties/AssemblyInfo.cs
+++ b/src/Rhythm.Caching.Umbraco/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/src/Rhythm.Caching.Umbraco/Rhythm.Caching.Umbraco.csproj
+++ b/src/Rhythm.Caching.Umbraco/Rhythm.Caching.Umbraco.csproj
@@ -38,9 +38,6 @@
     <Reference Include="AutoMapper, Version=8.1.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoMapper.8.1.0\lib\net461\AutoMapper.dll</HintPath>
     </Reference>
-    <Reference Include="BouncyCastle.Crypto, Version=1.8.3.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
-      <HintPath>..\packages\BouncyCastle.1.8.3.1\lib\BouncyCastle.Crypto.dll</HintPath>
-    </Reference>
     <Reference Include="ClientDependency.Core, Version=1.9.7.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ClientDependency.1.9.7\lib\net45\ClientDependency.Core.dll</HintPath>
     </Reference>
@@ -48,17 +45,11 @@
       <HintPath>..\packages\ClientDependency-Mvc5.1.8.0.0\lib\net45\ClientDependency.Core.Mvc.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="CookComputing.XmlRpcV2, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a7d6e17aa302004d, processorArchitecture=MSIL">
-      <HintPath>..\packages\xmlrpcnet.3.0.0.266\lib\net20\CookComputing.XmlRpcV2.dll</HintPath>
-    </Reference>
     <Reference Include="CSharpTest.Net.Collections, Version=14.906.1403.1082, Culture=neutral, PublicKeyToken=06aee00cce822474, processorArchitecture=MSIL">
       <HintPath>..\packages\CSharpTest.Net.Collections.14.906.1403.1082\lib\net40\CSharpTest.Net.Collections.dll</HintPath>
     </Reference>
     <Reference Include="Examine, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Examine.1.0.1\lib\net452\Examine.dll</HintPath>
-    </Reference>
-    <Reference Include="Google.Protobuf, Version=3.6.1.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Protobuf.3.6.1\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.11.4.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlAgilityPack.1.11.4\lib\Net45\HtmlAgilityPack.dll</HintPath>
@@ -68,9 +59,6 @@
     </Reference>
     <Reference Include="ImageProcessor, Version=2.7.0.100, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ImageProcessor.2.7.0.100\lib\net452\ImageProcessor.dll</HintPath>
-    </Reference>
-    <Reference Include="ImageProcessor.Web, Version=4.10.0.100, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ImageProcessor.Web.4.10.0.100\lib\net452\ImageProcessor.Web.dll</HintPath>
     </Reference>
     <Reference Include="LightInject, Version=5.4.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\LightInject.5.4.0\lib\net46\LightInject.dll</HintPath>
@@ -132,9 +120,6 @@
     </Reference>
     <Reference Include="MiniProfiler.Shared, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b44f9351044011a3, processorArchitecture=MSIL">
       <HintPath>..\packages\MiniProfiler.Shared.4.0.165\lib\net461\MiniProfiler.Shared.dll</HintPath>
-    </Reference>
-    <Reference Include="MySql.Data, Version=8.0.16.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
-      <HintPath>..\packages\MySql.Data.8.0.16\lib\net452\MySql.Data.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -260,10 +245,6 @@
     </Reference>
     <Reference Include="Umbraco.Web.UI, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Web.8.0.2\lib\net472\Umbraco.Web.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="UrlRewritingNet.UrlRewriter, Version=2.0.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UrlRewritingNet.2.0.7\lib\UrlRewritingNet.UrlRewriter.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Rhythm.Caching.Umbraco/Rhythm.Caching.Umbraco.csproj
+++ b/src/Rhythm.Caching.Umbraco/Rhythm.Caching.Umbraco.csproj
@@ -35,8 +35,8 @@
     <DocumentationFile>bin\Release\Rhythm.Caching.Umbraco.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=8.1.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.8.1.0\lib\net461\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=8.0.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.8.0.0\lib\net461\AutoMapper.dll</HintPath>
     </Reference>
     <Reference Include="ClientDependency.Core, Version=1.9.7.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ClientDependency.1.9.7\lib\net45\ClientDependency.Core.dll</HintPath>
@@ -48,8 +48,8 @@
     <Reference Include="CSharpTest.Net.Collections, Version=14.906.1403.1082, Culture=neutral, PublicKeyToken=06aee00cce822474, processorArchitecture=MSIL">
       <HintPath>..\packages\CSharpTest.Net.Collections.14.906.1403.1082\lib\net40\CSharpTest.Net.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="Examine, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Examine.1.0.1\lib\net452\Examine.dll</HintPath>
+    <Reference Include="Examine, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Examine.1.0.0\lib\net452\Examine.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.11.4.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlAgilityPack.1.11.4\lib\Net45\HtmlAgilityPack.dll</HintPath>
@@ -116,7 +116,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MiniProfiler, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b44f9351044011a3, processorArchitecture=MSIL">
-      <HintPath>..\packages\MiniProfiler.4.0.165\lib\net461\MiniProfiler.dll</HintPath>
+      <HintPath>..\packages\MiniProfiler.4.0.138\lib\net461\MiniProfiler.dll</HintPath>
     </Reference>
     <Reference Include="MiniProfiler.Shared, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b44f9351044011a3, processorArchitecture=MSIL">
       <HintPath>..\packages\MiniProfiler.Shared.4.0.165\lib\net461\MiniProfiler.Shared.dll</HintPath>

--- a/src/Rhythm.Caching.Umbraco/Rhythm.Caching.Umbraco.csproj
+++ b/src/Rhythm.Caching.Umbraco/Rhythm.Caching.Umbraco.csproj
@@ -119,7 +119,7 @@
       <HintPath>..\packages\MiniProfiler.4.0.138\lib\net461\MiniProfiler.dll</HintPath>
     </Reference>
     <Reference Include="MiniProfiler.Shared, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b44f9351044011a3, processorArchitecture=MSIL">
-      <HintPath>..\packages\MiniProfiler.Shared.4.0.165\lib\net461\MiniProfiler.Shared.dll</HintPath>
+      <HintPath>..\packages\MiniProfiler.Shared.4.0.138\lib\net461\MiniProfiler.Shared.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/Rhythm.Caching.Umbraco/packages.config
+++ b/src/Rhythm.Caching.Umbraco/packages.config
@@ -33,7 +33,7 @@
   <package id="Microsoft.Owin.Security.OAuth" version="4.0.1" targetFramework="net472" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" developmentDependency="true" />
   <package id="MiniProfiler" version="4.0.138" targetFramework="net472" developmentDependency="true" />
-  <package id="MiniProfiler.Shared" version="4.0.165" targetFramework="net472" />
+  <package id="MiniProfiler.Shared" version="4.0.138" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" developmentDependency="true" />
   <package id="NPoco" version="3.9.4" targetFramework="net472" />
   <package id="NuGet.CommandLine" version="5.0.2" targetFramework="net472" developmentDependency="true" />

--- a/src/Rhythm.Caching.Umbraco/packages.config
+++ b/src/Rhythm.Caching.Umbraco/packages.config
@@ -1,15 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoMapper" version="8.1.0" targetFramework="net472" developmentDependency="true" />
-  <package id="BouncyCastle" version="1.8.3.1" targetFramework="net472" />
   <package id="ClientDependency" version="1.9.7" targetFramework="net472" developmentDependency="true" />
   <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net452" developmentDependency="true" />
   <package id="CSharpTest.Net.Collections" version="14.906.1403.1082" targetFramework="net472" />
   <package id="Examine" version="1.0.1" targetFramework="net472" developmentDependency="true" />
-  <package id="Google.Protobuf" version="3.6.1" targetFramework="net472" />
   <package id="HtmlAgilityPack" version="1.11.4" targetFramework="net472" developmentDependency="true" />
   <package id="ImageProcessor" version="2.7.0.100" targetFramework="net472" developmentDependency="true" />
-  <package id="ImageProcessor.Web" version="4.10.0.100" targetFramework="net472" developmentDependency="true" />
   <package id="LightInject" version="5.4.0" targetFramework="net472" />
   <package id="LightInject.Annotation" version="1.1.0" targetFramework="net472" />
   <package id="LightInject.Mvc" version="2.0.0" targetFramework="net472" />
@@ -37,7 +34,6 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" developmentDependency="true" />
   <package id="MiniProfiler" version="4.0.165" targetFramework="net472" developmentDependency="true" />
   <package id="MiniProfiler.Shared" version="4.0.165" targetFramework="net472" />
-  <package id="MySql.Data" version="8.0.16" targetFramework="net472" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" developmentDependency="true" />
   <package id="NPoco" version="3.9.4" targetFramework="net472" />
   <package id="NuGet.CommandLine" version="5.0.2" targetFramework="net472" developmentDependency="true" />
@@ -61,6 +57,4 @@
   <package id="Umbraco.SqlServerCE" version="4.0.0.1" targetFramework="net472" />
   <package id="UmbracoCms.Core" version="8.0.2" targetFramework="net472" />
   <package id="UmbracoCms.Web" version="8.0.2" targetFramework="net472" />
-  <package id="UrlRewritingNet" version="2.0.7" targetFramework="net452" developmentDependency="true" />
-  <package id="xmlrpcnet" version="3.0.0.266" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/src/Rhythm.Caching.Umbraco/packages.config
+++ b/src/Rhythm.Caching.Umbraco/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="8.1.0" targetFramework="net472" developmentDependency="true" />
+  <package id="AutoMapper" version="8.0.0" targetFramework="net472" developmentDependency="true" />
   <package id="ClientDependency" version="1.9.7" targetFramework="net472" developmentDependency="true" />
   <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net452" developmentDependency="true" />
   <package id="CSharpTest.Net.Collections" version="14.906.1403.1082" targetFramework="net472" />
-  <package id="Examine" version="1.0.1" targetFramework="net472" developmentDependency="true" />
+  <package id="Examine" version="1.0.0" targetFramework="net472" developmentDependency="true" />
   <package id="HtmlAgilityPack" version="1.11.4" targetFramework="net472" developmentDependency="true" />
   <package id="ImageProcessor" version="2.7.0.100" targetFramework="net472" developmentDependency="true" />
   <package id="LightInject" version="5.4.0" targetFramework="net472" />
@@ -32,7 +32,7 @@
   <package id="Microsoft.Owin.Security.Cookies" version="4.0.1" targetFramework="net472" developmentDependency="true" />
   <package id="Microsoft.Owin.Security.OAuth" version="4.0.1" targetFramework="net472" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" developmentDependency="true" />
-  <package id="MiniProfiler" version="4.0.165" targetFramework="net472" developmentDependency="true" />
+  <package id="MiniProfiler" version="4.0.138" targetFramework="net472" developmentDependency="true" />
   <package id="MiniProfiler.Shared" version="4.0.165" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" developmentDependency="true" />
   <package id="NPoco" version="3.9.4" targetFramework="net472" />


### PR DESCRIPTION
A review of nuget packages that are now no longer required with the move from v7 to v8. This includes discontinued UmbracoCms dependencies and packages that live in other libraries.

Additionally package versions have been lowered to match v8.0.2 instead of the latest version.